### PR TITLE
Clean up json parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json_str"
-version = "0.3.4"
+version = "0.4.0"
 authors = ["Ashley Mannix <ashleymannix@live.com.au>"]
 license = "Apache-2.0"
 description = "Write json literals without ugly strings."
@@ -9,7 +9,7 @@ repository = "https://github.com/KodrAus/json_str"
 
 [lib]
 name = "json_str"
-crate_type = [ "dylib" ]
+crate_type = [ "lib" ]
 plugin = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/KodrAus/json_str"
 
 [lib]
 name = "json_str"
-crate_type = [ "lib" ]
+crate_type = [ "rlib", "dylib" ]
 plugin = true
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,7 @@
 //!
 //! The `json_str!` macro will take an inline token tree and return a sanitised json `String`:
 //!
-//! ```
-//! # #![feature(plugin)]
-//! # #![plugin(json_str)]
-//! # fn main() {
+//! ```ignore
 //! let json = json_str!({
 //! 	"query": {
 //! 		"filtered": {
@@ -73,15 +70,11 @@
 //! 		}
 //! 	}
 //! });
-//! # }
 //! ```
 //!
 //! This will also work for unquoted keys for something a bit more `rusty`:
 //!
-//! ```
-//! # #![feature(plugin)]
-//! # #![plugin(json_str)]
-//! # fn main() {
+//! ```ignore
 //! let json = json_str!({
 //! 	query: {
 //! 		filtered: {
@@ -100,17 +93,13 @@
 //! 		}
 //! 	}
 //! });
-//! # }
 //! ```
 //!
 //! On `nightly`, there's an additional plugin called `json_lit` that returns a `&'static str`
 //! instead of a `String`, so you can avoid allocating each time. The syntax is otherwise the same
 //! as `json_str`:
 //!
-//! ```
-//! # #![feature(plugin)]
-//! # #![plugin(json_str)]
-//! # fn main() {
+//! ```ignore
 //! let json = json_lit!({
 //! 	"query": {
 //! 		"filtered": {
@@ -129,7 +118,6 @@
 //! 		}
 //! 	}
 //! });
-//! # }
 //! ```
 //!
 //! For json values that can't be fully determined at compile-time,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -47,12 +47,12 @@ fn sanitisation_removes_whitespace() {
 
 #[test]
 fn sanitisation_does_not_affect_strings() {
-	let j = "\n{ \"a\" : \"stuff and data.\n 	More.\"}";
+	let j = "\n{ \"a\" : \"stuff and data.\n 	More.\", \"b\":\"色は匂へど 散りぬるを\"}";
 
 	let mut sanitised = String::new();
 	sanitise(j.as_bytes(), &mut sanitised);
 
-	assert_eq!("{\"a\":\"stuff and data.\n 	More.\"}", &sanitised);
+	assert_eq!("{\"a\":\"stuff and data.\n 	More.\",\"b\":\"色は匂へど 散りぬるを\"}", &sanitised);
 }
 
 #[test]


### PR DESCRIPTION
Just a bit of boy-scouting while I'm in the area. Removes some redundant junk from `parse` and makes it a bit more efficient by not doing unnecessary checks.

Based off #6 