### PR TITLE
Accept escaped strings

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,104 +2,107 @@ use std::str;
 
 //TODO: Should take json state. Don't check for special values if parsing key
 pub fn sanitise(remainder: &[u8], sanitised: &mut String) {
-	if remainder.len() == 0 {
-		return;
-	}
+    if remainder.len() == 0 {
+        return;
+    }
 
-	let current = remainder[0];
+    let current = remainder[0];
 
-	match current {
-		//Key
-		b'"'|b'\'' => {
-			let (rest, key) = take_while(&remainder[1..], |c| c != current);
+    match current {
+        //Key
+        b'"'|b'\'' => {
+            enum StringState {
+                Unescaped,
+                Escaped
+            }
 
-			sanitised.push('"');
-			sanitised.push_str(key);
-			sanitised.push('"');
+            let (rest, key) = take_while(&remainder[1..], StringState::Unescaped, 
+                |s, c| {
+                    match (s, c) {
+                        //Escape char
+                        (StringState::Unescaped, b'\\') => {
+                            (StringState::Escaped, true)
+                        },
+                        //Ignore char after escape
+                        (StringState::Escaped, _) => {
+                            (StringState::Unescaped, true)
+                        },
+                        //Unescaped quote
+                        (StringState::Unescaped, c) if c == current => {
+                            (StringState::Unescaped, false)
+                        },
+                        //Anything else
+                        _ => {
+                            (StringState::Unescaped, true)
+                        }
+                    }
+                }
+            );
 
-			sanitise(&rest[1..], sanitised)
-		},
-		//Start of item
-		b'{'|b'['|b':' => {
-			sanitised.push(current as char);
+            sanitised.push('"');
+            sanitised.push_str(key);
+            sanitised.push('"');
 
-			sanitise(&remainder[1..], sanitised)
-		},
-		//Unquoted strings
-		b if (b as char).is_alphabetic() => {
-			let (rest, key) = take_while1(&remainder, |c|
-				(c as char).is_alphabetic() ||
-				c == b'_' ||
-				c == b'.'
-			);
+            sanitise(&rest[1..], sanitised)
+        },
+        //Start of item
+        b'{'|b'['|b':' => {
+            sanitised.push(current as char);
 
-			//Check if the string is a special value; true, false or null
-			//For special values, push them as straight unquoted values. Otherwise, quote them
-			match key {
-				"true"|"false"|"null" =>
-					sanitised.push_str(key),
-				_ => {
-					sanitised.push('"');
-					sanitised.push_str(key);
-					sanitised.push('"');
-				}
-			}
+            sanitise(&remainder[1..], sanitised)
+        },
+        //Unquoted strings
+        b if (b as char).is_alphabetic() => {
+            let (rest, key) = take_while(&remainder, (), |_, c| {
+                let more = (c as char).is_alphabetic() ||
+                            c == b'_' ||
+                            c == b'.';
 
-			sanitise(rest, sanitised)
-		},
-		//Trim whitespace
-		b' '|b'\r'|b'\n'|b'\t' => {
-			sanitise(&remainder[1..], sanitised)
-		},
-		//Other chars
-		_ => {
-			sanitised.push(current as char);
+                ((), more)
+            });
 
-			sanitise(&remainder[1..], sanitised)
-		}
-	}
+            //Check if the string is a special value; true, false or null
+            //For special values, push them as straight unquoted values. Otherwise, quote them
+            match key {
+                "true"|"false"|"null" =>
+                    sanitised.push_str(key),
+                _ => {
+                    sanitised.push('"');
+                    sanitised.push_str(key);
+                    sanitised.push('"');
+                }
+            }
+
+            sanitise(rest, sanitised)
+        },
+        //Trim whitespace
+        b' '|b'\r'|b'\n'|b'\t' => {
+            sanitise(&remainder[1..], sanitised)
+        },
+        //Other chars
+        _ => {
+            sanitised.push(current as char);
+
+            sanitise(&remainder[1..], sanitised)
+        }
+    }
 }
 
-pub fn shift_while<F>(i: &[u8], f: F) -> &[u8] where F: Fn(u8) -> bool {
-	let mut ctr = 0;
-	for c in i {
-		if f(*c) {
-			ctr += 1;
-		}
-		else {
-			break;
-		}
-	}
+pub fn take_while<F, S>(i: &[u8], mut s: S, f: F) -> (&[u8], &str) 
+    where F: Fn(S, u8) -> (S, bool) 
+{
+    let mut ctr = 0;
 
-	&i[ctr..]
-}
+    for c in i {
+        let (new_state, more) = f(s, *c);
+        if more {
+            s = new_state;
+            ctr += 1;
+        }
+        else {
+            break;
+        }
+    }
 
-pub fn take_while<F>(i: &[u8], f: F) -> (&[u8], &str) where F: Fn(u8) -> bool {
-	let mut ctr = 0;
-
-	for c in i {
-		if f(*c) {
-			ctr += 1;
-		}
-		else {
-			break;
-		}
-	}
-
-	(&i[ctr..], unsafe { str::from_utf8_unchecked(&i[0..ctr]) })
-}
-
-pub fn take_while1<F>(i: &[u8], f: F) -> (&[u8], &str) where F: Fn(u8) -> bool {
-	let mut ctr = 0;
-
-	for c in i {
-		if f(*c) || ctr == 0 {
-			ctr += 1;
-		}
-		else {
-			break;
-		}
-	}
-
-	(&i[ctr..], unsafe { str::from_utf8_unchecked(&i[0..ctr]) })
+    (&i[ctr..], unsafe { str::from_utf8_unchecked(&i[0..ctr]) })
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -56,6 +56,16 @@ fn sanitisation_does_not_affect_strings() {
 }
 
 #[test]
+fn sanitisation_recognises_escaped_strings() {
+	let j = r#"{"a":"a \"quoted'\" string'. \"\\"}"#;
+
+	let mut sanitised = String::new();
+	sanitise(j.as_bytes(), &mut sanitised);
+
+	assert_eq!(r#"{"a":"a \"quoted'\" string'. \"\\"}"#, &sanitised);
+}
+
+#[test]
 fn sanitisation_standardises_quotes() {
 	let j = "{ 'a' : \"stuff\", \"b\":{  \"c\":[ '0', 1 ] },\"d\":14 }";
 


### PR DESCRIPTION
Closes #8 
Tweaks the parser to accept escaped strings. It also removes some other unnecessary parsing bits.